### PR TITLE
86c18c3jb Implement hook_civicrm_enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Kin Cooperative CiviCRM Extension
 
-This is an [extension for CiviCRM](https://docs.civicrm.org/sysadmin/en/latest/customize/extensions/), licensed under [AGPL-3.0](LICENSE.txt).
-It contains modifications to CiviCRM functionality as currently required for the
-Kin website.
+This is an [extension for CiviCRM](https://docs.civicrm.org/sysadmin/en/latest/customize/extensions/),
+licensed under [AGPL-3.0](LICENSE.txt). It contains modifications to CiviCRM functionality as currently
+required for the Kin website.
 
 ## Development
 
 Branches and commits will be prefixed with task IDs corresponding to Kin Coop's
 [ClickUp account](https://app.clickup.com/9015543787/home).
+
+In the interest of getting the Kin proof-of-concept up and running, there are no automated tests yet.

--- a/kincoop.php
+++ b/kincoop.php
@@ -4,6 +4,27 @@ require_once 'kincoop.civix.php';
 
 use CRM_Kincoop_ExtensionUtil as E;
 
+const GIFT_FT_NAME = 'Gift';
+
+const REVERSIBLE_AMOUNT_KEYS = array(
+  'line_total' => TRUE,
+  'line_total_inclusive' => TRUE,
+  'net_amount' => TRUE,
+  'total_amount' => TRUE,
+  'unit_price' => TRUE,
+);
+
+/**
+ * Implements hook_civicrm_pre
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_pre
+ */
+function kincoop_civicrm_pre($op, $objectName, $id, &$params) {
+  if (isGiftRequest($op, $objectName, $params['financial_type_id'])) {
+    array_walk_recursive($params, 'reverse_sign_if_appropriate');
+  }
+}
+
 /**
  * Implements hook_civicrm_config().
  *
@@ -29,4 +50,30 @@ function kincoop_civicrm_install(): void {
  */
 function kincoop_civicrm_enable(): void {
   _kincoop_civix_civicrm_enable();
+}
+
+function isGiftRequest($op, $objectName, $financialTypeId): bool {
+  return $objectName == 'Contribution' && $op == 'create' && isAssociatedWithGift($financialTypeId);
+}
+
+function isAssociatedWithGift($financial_type_id): bool {
+  $ftName = CRM_Core_DAO::singleValueQuery('SELECT name FROM civicrm_financial_type WHERE id = %1',
+    array(1 => array($financial_type_id, 'Integer')));
+  return $ftName == GIFT_FT_NAME;
+}
+
+function reverse_sign_if_appropriate(&$item, $key): void {
+  if (!isReversibleAmount($key)) {
+    return;
+  }
+  if (is_numeric($item)) {
+    $item = -$item;
+  } elseif (is_string($item)) {
+    $item = '-' . $item;
+  }
+}
+
+function isReversibleAmount($key): bool
+{
+  return array_key_exists($key, REVERSIBLE_AMOUNT_KEYS);
 }


### PR DESCRIPTION
This hook will intercept any contribution creations that are associated with the 'Gift' financial type. Note that this financial type is not native to CiviCRM; it needs to be created.

For every such contribution, the hook will result in a negative sign on each of the following entries:

* `amount` in `civicrm_financial_item`
* `unit_price` and `line_total` in `civicrm_line_item`
* `total_amount` and `net_amount` in `civicrm_financial_trxn`

It is assumed that fees and taxes for these contributions are zero.