### PR TITLE
86c19qqgk When rule trigger is associated with gift request, make the household the contact

### DIFF
--- a/kincoop.php
+++ b/kincoop.php
@@ -20,8 +20,10 @@ const REVERSIBLE_AMOUNT_KEYS = array(
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_pre
  */
 function kincoop_civicrm_pre($op, $objectName, $id, &$params) {
-  if (isNewContribution($objectName, $op) && isAssociatedWithGift($params)) {
-    reverseSignsOnAmounts($params);
+  if(isset($params['financial_type_id'])) {
+    if (isNewContribution($objectName, $op) && isAssociatedWithGift($params)) {
+      reverseSignsOnAmounts($params);
+    }
   }
 }
 


### PR DESCRIPTION
This hook facilitates the sending of an email notification to the household admin when a member requests a gift.

There needs to be a rule with the following characteristics.

* Trigger: "Contribution is added"
* Condition: "Contribution is (not) of Financial Type(s)"
  * FT is Gift
* Action: "Send Email to a related contact"
  * Relationship Type is "Household Admin is"

The hook will change the contact ID targeted by the rule trigger from the member's to the household's. Without doing this, emails would get sent to _all_ of the member's households' admins.